### PR TITLE
chore(update): Update Prerender Rails to version 1.9.0 from Upstream Repo

### DIFF
--- a/lib/prerender_rails.rb
+++ b/lib/prerender_rails.rb
@@ -48,7 +48,8 @@ module Rack
         'Discordbot',
         'Google Page Speed',
         'Qwantify',
-        'Chrome-Lighthouse'
+        'Chrome-Lighthouse',
+        'TelegramBot'
       ]
 
       @extensions_to_ignore = [

--- a/lib/prerender_rails.rb
+++ b/lib/prerender_rails.rb
@@ -19,6 +19,7 @@ module Rack
 
       @crawler_user_agents = [
         'googlebot',
+        'Google-InspectionTool',
         'yahoo',
         'bingbot',
         'baiduspider',

--- a/prerender_rails.gemspec
+++ b/prerender_rails.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "prerender_rails"
-  spec.version       = "1.8.0"
+  spec.version       = "1.9.0"
   spec.authors       = ["Todd Hooper"]
   spec.email         = ["todd@prerender.io"]
   spec.description   = %q{Rails middleware to prerender your javascript heavy pages on the fly by a phantomjs service}

--- a/prerender_rails.gemspec
+++ b/prerender_rails.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "prerender_rails"
-  spec.version       = "1.7.0"
+  spec.version       = "1.8.0"
   spec.authors       = ["Todd Hooper"]
   spec.email         = ["todd@prerender.io"]
   spec.description   = %q{Rails middleware to prerender your javascript heavy pages on the fly by a phantomjs service}


### PR DESCRIPTION
Version 1.9.0 adds a hotfix for Google's new bot.